### PR TITLE
Create Helper Method to Determine Attendees of Both Event and Meeting

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 public final class FindMeetingQuery {
   /**
     * Returns whether or not an event is attended by the required attendees from the Meeting Request
+    *
     @param Event event The input event to compare against
     @param Request request The subject meeting request
     @return a boolean value that is true if the event and request have overlapping attendees.

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -17,6 +17,20 @@ package com.google.sps;
 import java.util.Collection;
 
 public final class FindMeetingQuery {
+  /**
+    Returns whether or not an event is attended by the required attendees from the Meeting Request
+    @param Event event The input event to compare against
+    @param Request request The subject meeting request
+    @return a boolean value that is true if the event and request have overlapping attendees.
+  */
+  private static boolean isAttended(Event event, MeetingRequest request) {
+    Collection<String> eventAttendees = event.getAttendees();
+    Collection<String> requestAttendees = request.getAttendees();
+    for(String attendee : eventAttendees) if(requestAttendees.contains(attendee)) return true;
+
+    return false; // Fallback if no attendees are found in the both the meeting and the request
+  }
+
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     throw new UnsupportedOperationException("TODO: Implement this method.");
   }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -28,7 +28,7 @@ public final class FindMeetingQuery {
     Collection<String> requestAttendees = request.getAttendees();
     for(String attendee : eventAttendees) if(requestAttendees.contains(attendee)) return true;
 
-    return false; // Fallback if no attendees are found in the both the meeting and the request
+    return false; // Fallback if no attendees are found in the both the event and the meeting request
   }
 
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -29,7 +29,7 @@ public final class FindMeetingQuery {
     Collection<String> requestAttendees = request.getAttendees();
     for (String attendee : eventAttendees) if (requestAttendees.contains(attendee)) return true;
 
-    return false; // Fallback if no attendees are found in the both the event and the meeting request
+    return false; // Fallback for if no attendees are found that belong to both the event and the meeting request
   }
 
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -27,7 +27,7 @@ public final class FindMeetingQuery {
   private static boolean isAttended(Event event, MeetingRequest request) {
     Collection<String> eventAttendees = event.getAttendees();
     Collection<String> requestAttendees = request.getAttendees();
-    for(String attendee : eventAttendees) if(requestAttendees.contains(attendee)) return true;
+    for (String attendee : eventAttendees) if (requestAttendees.contains(attendee)) return true;
 
     return false; // Fallback if no attendees are found in the both the event and the meeting request
   }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -21,7 +21,7 @@ public final class FindMeetingQuery {
     * Returns whether or not an event is attended by the required attendees from the Meeting Request
     *
     @param Event event The input event to compare against
-    @param Request request The subject meeting request
+    @param MeetingRequest request The subject meeting request
     @return a boolean value that is true if the event and request have overlapping attendees.
   */
   private static boolean isAttended(Event event, MeetingRequest request) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -18,7 +18,7 @@ import java.util.Collection;
 
 public final class FindMeetingQuery {
   /**
-    Returns whether or not an event is attended by the required attendees from the Meeting Request
+    * Returns whether or not an event is attended by the required attendees from the Meeting Request
     @param Event event The input event to compare against
     @param Request request The subject meeting request
     @return a boolean value that is true if the event and request have overlapping attendees.


### PR DESCRIPTION
This PR merges a helper method for the FindMeetingQuery.query method. 

This helper method, isAttended, **determines whether or not an Event's attendees overlap with the required attendees of a Meeting Request**. The method returns a boolean indicator for attendance overlap.
_The helper achieves this by looping through the Event Attendees and returning true if the attendee appears in Meeting Request Attendees, ultimately returning false if the loop terminates._

This method will be used to determine whether an event has to be considered when marking the free slots.