### PR TITLE
Add Helper to Convert from Half Hour Slots to Minutes Elapsed

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -40,6 +40,7 @@ public final class FindMeetingQuery {
   */
   private static int getTime(int halfHour) {
     if(halfHour < 0 || halfHour > 47 ) throw new IllegalArgumentException("Time out of bounds.");
+    
     return halfHour * 30;
   }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -32,7 +32,12 @@ public final class FindMeetingQuery {
     return false; // Fallback for if no attendees are found that belong to both the event and the meeting request
   }
 
-  /**Returns the minutes in a day from a half hour slot*/
+  /**
+    * Returns the minutes in a day from a half hour slot
+    *
+    @param int halfHour The halfhour slot to be converted
+    @exception IllegalArgumentException thrown if slot > 0 or slot > 47.
+  */
   private static int getTime(int halfHour) {
     if(halfHour < 0 || halfHour > 47 ) throw new IllegalArgumentException("Time out of bounds.");
     return halfHour == 0 ? 0 : halfHour * 30;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -33,7 +33,7 @@ public final class FindMeetingQuery {
   }
 
   /**
-    * Returns the minutes in a day from a half hour slot
+    * Returns the minutes in a day from a half hour slot.
     *
     @param int halfHour The halfhour slot to be converted.
     @exception IllegalArgumentException thrown if slot > 0 or slot > 47.

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -38,7 +38,7 @@ public final class FindMeetingQuery {
     @param int halfHour The halfhour slot to be converted.
     @exception IllegalArgumentException thrown if slot < 0 or slot > 47.
   */
-  private static int convertToMinuteTimestamp(int halfHour) {
+  protected static int convertToMinuteTimestamp(int halfHour) {
     if(halfHour < 0 || halfHour > 47 ) throw new IllegalArgumentException("Time out of bounds.");
     
     return halfHour * 30;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -36,7 +36,7 @@ public final class FindMeetingQuery {
     * Returns the minutes in a day from a half hour slot.
     *
     @param int halfHour The halfhour slot to be converted.
-    @exception IllegalArgumentException thrown if slot > 0 or slot > 47.
+    @exception IllegalArgumentException thrown if slot < 0 or slot > 47.
   */
   private static int getTime(int halfHour) {
     if(halfHour < 0 || halfHour > 47 ) throw new IllegalArgumentException("Time out of bounds.");

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -32,6 +32,12 @@ public final class FindMeetingQuery {
     return false; // Fallback for if no attendees are found that belong to both the event and the meeting request
   }
 
+  /**Returns the minutes in a day from a half hour slot*/
+  private static int getTime(int halfHour) {
+    if(halfHour < 0 || halfHour > 47 ) throw new IllegalArgumentException("Time out of bounds.");
+    return halfHour == 0 ? 0 : halfHour * 30;
+  }
+
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     throw new UnsupportedOperationException("TODO: Implement this method.");
   }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -35,7 +35,7 @@ public final class FindMeetingQuery {
   /**
     * Returns the minutes in a day from a half hour slot
     *
-    @param int halfHour The halfhour slot to be converted
+    @param int halfHour The halfhour slot to be converted.
     @exception IllegalArgumentException thrown if slot > 0 or slot > 47.
   */
   private static int getTime(int halfHour) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -38,7 +38,7 @@ public final class FindMeetingQuery {
     @param int halfHour The halfhour slot to be converted.
     @exception IllegalArgumentException thrown if slot < 0 or slot > 47.
   */
-  private static int getTime(int halfHour) {
+  private static int convertToMinuteTimestamp(int halfHour) {
     if(halfHour < 0 || halfHour > 47 ) throw new IllegalArgumentException("Time out of bounds.");
     
     return halfHour * 30;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -40,7 +40,7 @@ public final class FindMeetingQuery {
   */
   private static int getTime(int halfHour) {
     if(halfHour < 0 || halfHour > 47 ) throw new IllegalArgumentException("Time out of bounds.");
-    return halfHour == 0 ? 0 : halfHour * 30;
+    return halfHour * 30;
   }
 
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -274,12 +274,14 @@ public final class FindMeetingQueryTest {
   @Test(expected =  IllegalArgumentException.class)
   public void slotBelowRange() {
     // Since slot < 0, we expect an IllegalArgumentException to be thrown.
+
     query.convertToMinuteTimestamp(-1);
   }
 
   @Test(expected =  IllegalArgumentException.class)
   public void slotAboveRange() {
     // Since slot > 47, we expect an IllegalArgumentException to be thrown.
+
     query.convertToMinuteTimestamp(48);
   }
 
@@ -287,16 +289,20 @@ public final class FindMeetingQueryTest {
   public void slotOnBoundary() {
     // The result should be the number of minutes elapsed up to the last half hour of the day.
     int slot = 47;
+
     int actual = query.convertToMinuteTimestamp(slot);
     int expected = 1410;
+
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void slotInRangeNotBoundary() {
     int slot = 16;
+    
     int actual = query.convertToMinuteTimestamp(slot);
     int expected = slot * 30;
+
     Assert.assertEquals(expected, actual);
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -270,5 +270,15 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
+
+  @Test(expected =  IllegalArgumentException.class)
+  public void slotBelowRange() {
+    query.convertToMinuteTimestamp(-1);
+  }
+
+  @Test(expected =  IllegalArgumentException.class)
+  public void slotAboveRange() {
+    query.convertToMinuteTimestamp(48);
+  }
 }
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -273,12 +273,31 @@ public final class FindMeetingQueryTest {
 
   @Test(expected =  IllegalArgumentException.class)
   public void slotBelowRange() {
+    // Since slot < 0, we expect an IllegalArgumentException to be thrown.
     query.convertToMinuteTimestamp(-1);
   }
 
   @Test(expected =  IllegalArgumentException.class)
   public void slotAboveRange() {
+    // Since slot > 47, we expect an IllegalArgumentException to be thrown.
     query.convertToMinuteTimestamp(48);
+  }
+
+  @Test
+  public void slotOnBoundary() {
+    // The result should be the number of minutes elapsed up to the last half hour of the day.
+    int slot = 47;
+    int actual = query.convertToMinuteTimestamp(slot);
+    int expected = 1410;
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void slotInRangeNotBoundary() {
+    int slot = 16;
+    int actual = query.convertToMinuteTimestamp(slot);
+    int expected = slot * 30;
+    Assert.assertEquals(expected, actual);
   }
 }
 


### PR DESCRIPTION
This PR merges a method used to convert the time from a half hour slot, to a time in minutes.
The formula is **halfHour * 30**, where halfHour is an integer between 0 and 47 (inclusive bounds)

**The method rejects values outside the range of 0 and 47 with an Exception.**

This method is used after a valid Time Range has been found for a meeting to take place, to convert it into the format expected for the TimeRange Constructor.