### PR TITLE
Reduce Project Card Font and Container Size 

### DIFF
--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -195,11 +195,11 @@ a {
   display: flex;
   flex-direction: column;
   font-size: 2rem;
-  height: 70%;
+  height: 50%;
   justify-content: center;
   margin: auto;
   text-align: center;
-  width: 70%;
+  width: 50%;
 }
 
 .card,

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -194,7 +194,7 @@ a {
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  font-size: 2.5rem;
+  font-size: 2rem;
   height: 70%;
   justify-content: center;
   margin: auto;


### PR DESCRIPTION
This PR makes aesthetic changes to the project card section.

- **Reduce the size of the project cards** - The cards filled their containers a little too much, so the subjective decision was made to reduce them.
- **Reduce font size of headings in project cards** - Make the card heading font size more proportional to the size of the card.