### PR TITLE
Change Navigation Box on Scroll to Match Visible Section

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -12,8 +12,8 @@
         <option value="navigation">Jump to...</option>
         <option value="intro">Introduction</option>
         <option value="projects">Projects</option>
-        <option value="gallery">Gallery</option>
         <option value="contact">Contact</option>
+        <option value="gallery">Gallery</option>
       </select>
       <!-- TODO(samsog@google.com):Merge Navigation Section -->
       <div class="section" id="navigation">

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -59,8 +59,8 @@ const initialiseNavigation = () => {
 
 const onscroll = () => {
   const container = document.documentElement;
-  var scrollHeight = container.scrollHeight - container.clientHeight;
-  var scrollTop = container.scrollTop;
+  const scrollHeight = container.scrollHeight - container.clientHeight;
+  const scrollTop = container.scrollTop;
 }
 
 const onload = () => {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -70,10 +70,10 @@ const onscroll = () => {
   const percentage = Math.floor(scrollTop / scrollHeight * 100);
   const section = Math.floor(percentage / (100 / NUMBER_OF_SECTIONS));
 
-  // section == 5 is the comment section, which is not on the nav.
+  // section == COMMENT_SECTION represents comment section, which is not on the nav.
   const sectionSelector = document.getElementById('section-selector');
   if (section == COMMENT_SECTION) {
-    sectionSelector.selectedIndex = PROMPT_SECTION; // Index 0 is the "Jump to..." prompt.
+    sectionSelector.selectedIndex = PROMPT_SECTION; // PROMPT_SECTION is the "Jump to..." prompt.
   }
   else {
     sectionSelector.selectedIndex = section;

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -61,6 +61,9 @@ const onscroll = () => {
   const container = document.documentElement;
   const scrollHeight = container.scrollHeight - container.clientHeight;
   const scrollTop = container.scrollTop;
+
+  const percentage = Math.floor(scrollTop / scrollHeight * 100);
+  const section = Math.floor(percentage / 20);
 }
 
 const onload = () => {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -57,6 +57,12 @@ const initialiseNavigation = () => {
   });
 };
 
+const onscroll = () => {
+  const container = document.documentElement;
+  var scrollHeight = container.scrollHeight - container.clientHeight;
+  var scrollTop = container.scrollTop;
+}
+
 const onload = () => {
   new Promise((resolve, reject) => {
     getComments();

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -63,14 +63,17 @@ const onscroll = () => {
   const container = document.documentElement;
   const scrollHeight = container.scrollHeight - container.clientHeight;
   const scrollTop = container.scrollTop;
+  const PROMPT_SECTION = 0;
+  const COMMENT_SECTION = 5;
+  const NUMBER_OF_SECTIONS = 5;
 
   const percentage = Math.floor(scrollTop / scrollHeight * 100);
-  const section = Math.floor(percentage / 20);
+  const section = Math.floor(percentage / (100 / NUMBER_OF_SECTIONS));
 
   // section == 5 is the comment section, which is not on the nav.
   const sectionSelector = document.getElementById('section-selector');
-  if(section == 5) {
-    sectionSelector.selectedIndex = 0; // Index 0 is the "Jump to..." prompt.
+  if(section == COMMENT_SECTION) {
+    sectionSelector.selectedIndex = PROMPT_SECTION; // Index 0 is the "Jump to..." prompt.
   }
   else {
     sectionSelector.selectedIndex = section;

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -55,6 +55,8 @@ const initialiseNavigation = () => {
   sectionSelector.addEventListener('change', function (e) {
     navigate(e.target.value);
   });
+
+  document.body.onscroll = onscroll;
 };
 
 const onscroll = () => {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -64,6 +64,16 @@ const onscroll = () => {
 
   const percentage = Math.floor(scrollTop / scrollHeight * 100);
   const section = Math.floor(percentage / 20);
+
+  // section == 5 is the comment section, which is not on the nav.
+  const sectionSelector = document.getElementById('section-selector');
+  if(section == 5) {
+    sectionSelector.selectedIndex = 0; // Index 0 is the "Jump to..." prompt.
+  }
+  else {
+    sectionSelector.selectedIndex = section;
+  }
+
 }
 
 const onload = () => {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -72,7 +72,7 @@ const onscroll = () => {
 
   // section == 5 is the comment section, which is not on the nav.
   const sectionSelector = document.getElementById('section-selector');
-  if(section == COMMENT_SECTION) {
+  if (section == COMMENT_SECTION) {
     sectionSelector.selectedIndex = PROMPT_SECTION; // Index 0 is the "Jump to..." prompt.
   }
   else {


### PR DESCRIPTION
This PR implements a function that changes the **selectedIndex** of the fixed Navigation Box based on the percentage scrolled down the screen, relative to the container size.

The formula used to calculate the **current section = (containerScrollDistanceFromTop / containerScrollHeight * 100) / 20**

this will provide the percentage divided by 20, since there are 5 sections, each of which occupies exactly 20% of the container (since container size implicitly equals numberOfSections * viewheight).

Since the comment box is not on the navigation, the value of selectedIndex is set to 0, which represents the option value "Jump To..."

_The image below shows the value being affected_

![image](https://user-images.githubusercontent.com/47117318/90374346-43182600-e06b-11ea-9eb0-1a389c66aec1.png)
