### PR TITLE
Update Form Validation to Accept All Characters

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -114,7 +114,7 @@
             </div>
             <div class="form-element">
               <label>So, what'd you think?</label>
-              <input class="comment-io" name="comment" type="text" placeholder="I thought it was pretty cool, but..." pattern=".+" required>
+              <input class="comment-io" name="comment" type="text" placeholder="I thought it was pretty cool, but..." required>
             </div>
             <input type="submit" class="comment-io">
           </form>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -110,7 +110,7 @@
           <form id="comments-form" action="/data" method="POST">
             <div class="form-element">
               <label>Nickname</label>
-              <input class="comment-io" name="nickname" type="text" placeholder="Sam S" pattern=".+">
+              <input class="comment-io" name="nickname" type="text" placeholder="Sam S">
             </div>
             <div class="form-element">
               <label>So, what'd you think?</label>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -110,11 +110,11 @@
           <form id="comments-form" action="/data" method="POST">
             <div class="form-element">
               <label>Nickname</label>
-              <input class="comment-io" name="nickname" type="text" placeholder="Sam S" pattern="\w+">
+              <input class="comment-io" name="nickname" type="text" placeholder="Sam S" pattern=".+">
             </div>
             <div class="form-element">
               <label>So, what'd you think?</label>
-              <input class="comment-io" name="comment" type="text" placeholder="I thought it was pretty cool, but..." pattern="\w+" required>
+              <input class="comment-io" name="comment" type="text" placeholder="I thought it was pretty cool, but..." pattern=".+" required>
             </div>
             <input type="submit" class="comment-io">
           </form>


### PR DESCRIPTION
This PR changes the validation on the comments form to accept at least one of any characters. 
This is to make the descriptions more flexible, and to give users the freedom to type more expressively.

**Clarification:** the _nickname_ attribute is **purposefully** not required to allow commenters to remain somewhat anonymous. PR #28 Implements the changes related to this.