### PR TITLE
Add Image Files to Gallery (Slight Structural Change)

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -95,10 +95,10 @@
       <!-- TODO(samsog@google.com):Merge Gallery Section -->
       <div class="section" id="gallery">
         <div class="gallery-wrapper">
-          <div class="gallery-card tall img-1"></div>
-          <div class="gallery-card img-2"></div>
-          <div class="gallery-card img-3"></div>
-          <div class="gallery-card wide img-4"></div>
+          <div class="gallery-card tall img-museum"></div>
+          <div class="gallery-card img-house"></div>
+          <div class="gallery-card img-party"></div>
+          <div class="gallery-card wide img-restaurant"></div>
         </div>
       </div>
       <div class="section" id="comments">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -95,10 +95,10 @@
       <!-- TODO(samsog@google.com):Merge Gallery Section -->
       <div class="section" id="gallery">
         <div class="gallery-wrapper">
-          <img src="" alt="selfie of me in a suit" class="gallery-card tall">
-          <img src="" alt="selfie of me and my friends" class="gallery-card">
-          <img src="" alt="selfie of me in a park" class="gallery-card">
-          <img src="" alt="selfie of me smiling" class="gallery-card wide">
+          <div style="background-image:url(/images/IMG_1865.JPG)" alt="selfie of me in a suit" class="gallery-card tall"></div>
+          <div style="background-image:url(/images/IMG_1385.JPG)" alt="selfie of me and my friends" class="gallery-card"></div>
+          <div style="background-image:url(/images/IMG_3361.JPG)" alt="selfie of me in a park" class="gallery-card"></div>
+          <div style="background-image:url(/images/IMG_3866.JPG)" alt="selfie of me smiling" class="gallery-card wide"></div>
         </div>
       </div>
       <div class="section" id="comments">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -95,10 +95,10 @@
       <!-- TODO(samsog@google.com):Merge Gallery Section -->
       <div class="section" id="gallery">
         <div class="gallery-wrapper">
-          <div style="background-image:url(/images/IMG_1865.JPG)" class="gallery-card tall"></div>
-          <div style="background-image:url(/images/IMG_1385.JPG)" class="gallery-card"></div>
-          <div style="background-image:url(/images/IMG_3361.JPG)" class="gallery-card"></div>
-          <div style="background-image:url(/images/IMG_3866.JPG)" class="gallery-card wide"></div>
+          <div class="gallery-card tall img-1"></div>
+          <div class="gallery-card img-2"></div>
+          <div class="gallery-card img-3"></div>
+          <div class="gallery-card wide img-4"></div>
         </div>
       </div>
       <div class="section" id="comments">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -95,10 +95,10 @@
       <!-- TODO(samsog@google.com):Merge Gallery Section -->
       <div class="section" id="gallery">
         <div class="gallery-wrapper">
-          <div style="background-image:url(/images/IMG_1865.JPG)" alt="selfie of me in a suit" class="gallery-card tall"></div>
-          <div style="background-image:url(/images/IMG_1385.JPG)" alt="selfie of me and my friends" class="gallery-card"></div>
-          <div style="background-image:url(/images/IMG_3361.JPG)" alt="selfie of me in a park" class="gallery-card"></div>
-          <div style="background-image:url(/images/IMG_3866.JPG)" alt="selfie of me smiling" class="gallery-card wide"></div>
+          <div style="background-image:url(/images/IMG_1865.JPG)" class="gallery-card tall"></div>
+          <div style="background-image:url(/images/IMG_1385.JPG)" class="gallery-card"></div>
+          <div style="background-image:url(/images/IMG_3361.JPG)" class="gallery-card"></div>
+          <div style="background-image:url(/images/IMG_3866.JPG)" class="gallery-card wide"></div>
         </div>
       </div>
       <div class="section" id="comments">

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -275,19 +275,19 @@ a {
 }
 
 .img-museum {
-  background-image:url(/images/IMG_1865.JPG)
+  background-image: url(/images/IMG_1865.JPG);
 }
 
 .img-house {
-  background-image:url(/images/IMG_1385.JPG)
+  background-image: url(/images/IMG_1385.JPG);
 }
 
 .img-party {
-  background-image:url(/images/IMG_3361.JPG)
+  background-image: url(/images/IMG_3361.JPG);
 }
 
 .img-restaurant {
-  background-image:url(/images/IMG_3866.JPG)
+  background-image: url(/images/IMG_3866.JPG);
 }
 
 #comments {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -270,8 +270,8 @@ a {
 }
 
 .gallery-card.wide {
-  grid-column: span 2;
   background-position: left;
+  grid-column: span 2;
 }
 
 #comments {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -271,6 +271,7 @@ a {
 
 .gallery-card.wide {
   grid-column: span 2;
+  background-position: left;
 }
 
 #comments {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -274,6 +274,22 @@ a {
   grid-column: span 2;
 }
 
+.img-1 {
+  background-image:url(/images/IMG_1865.JPG)
+}
+
+.img-2 {
+  background-image:url(/images/IMG_1385.JPG)
+}
+
+.img-3 {
+  background-image:url(/images/IMG_3361.JPG)
+}
+
+.img-4 {
+  background-image:url(/images/IMG_3866.JPG)
+}
+
 #comments {
   align-items: center;
   background-color: var(--quaternary);

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -258,6 +258,8 @@ a {
 }
 
 .gallery-card {
+  background-size: cover;
+  background-position: center;
   grid-column: span 1;
   grid-row: span 1;
   outline: 3px white solid;

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -274,19 +274,19 @@ a {
   grid-column: span 2;
 }
 
-.img-1 {
+.img-museum {
   background-image:url(/images/IMG_1865.JPG)
 }
 
-.img-2 {
+.img-house {
   background-image:url(/images/IMG_1385.JPG)
 }
 
-.img-3 {
+.img-party {
   background-image:url(/images/IMG_3361.JPG)
 }
 
-.img-4 {
+.img-restaurant {
   background-image:url(/images/IMG_3866.JPG)
 }
 


### PR DESCRIPTION
This PR adds the image files imported from #46 to the Gallery Container. 

So that the images do not interfere with the the grid element dimensions, the images were added through the _background-image_ css attribute, each image being set to cover the size of the container.

**Since _<img>_ does not support the _background-image_ attribute, the grid elements were changed to divs**.

_Below is the product_

![image](https://user-images.githubusercontent.com/47117318/90386242-2e905980-e07c-11ea-84ee-79244bd421d4.png)
